### PR TITLE
Add React Native prototype with Firebase auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 .externalNativeBuild
 .cxx
 local.properties
+# Node and React Native files
+node_modules/
+react-native/node_modules/
+# React Native build directories
+react-native/android/app/build/
+react-native/ios/build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# WellTrack Mobile App
+
+This repository contains the original Android implementation and a new React Native prototype located in `react-native/`. The React Native version uses Firebase for authentication and data storage and lays the groundwork for future fitness tracking features.
+
+## React Native Features
+
+- Email signup/login via Firebase Auth
+- Onboarding form to collect goals and fitness level
+- Dashboard screen fetching user settings from Firestore
+
+Follow the instructions in `react-native/README.md` to run the prototype.

--- a/react-native/App.js
+++ b/react-native/App.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import AppNavigator from './src/navigation/AppNavigator';
+
+export default function App() {
+  return <AppNavigator />;
+}

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -1,0 +1,17 @@
+# WellTrack React Native
+
+This directory contains a React Native implementation of the WellTrack app with Firebase integration. It provides a starting point for authentication and onboarding screens that sync user data to Firestore.
+
+## Setup
+
+1. Install dependencies with `npm install` (requires Node.js and Expo CLI).
+2. Replace placeholder Firebase config values in `src/firebase/config.js`.
+3. Run the app with `npm start` or `expo start`.
+
+The app includes:
+
+- Email authentication using Firebase Auth
+- Onboarding screen to save fitness goals and level to Firestore
+- Dashboard screen that reads the saved data in real time
+
+Use this as a foundation to add the advanced fitness tracking and monetization features described in the project roadmap.

--- a/react-native/app.json
+++ b/react-native/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "welltrack",
+  "displayName": "WellTrack"
+}

--- a/react-native/babel.config.js
+++ b/react-native/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "welltrack",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "firebase": "^10.7.0"
+  }
+}

--- a/react-native/src/firebase/config.js
+++ b/react-native/src/firebase/config.js
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID'
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/react-native/src/navigation/AppNavigator.js
+++ b/react-native/src/navigation/AppNavigator.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/LoginScreen';
+import OnboardingScreen from '../screens/OnboardingScreen';
+import DashboardScreen from '../screens/DashboardScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function AppNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/react-native/src/screens/DashboardScreen.js
+++ b/react-native/src/screens/DashboardScreen.js
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { auth, db } from '../firebase/config';
+import { doc, onSnapshot } from 'firebase/firestore';
+
+export default function DashboardScreen() {
+  const [userData, setUserData] = useState(null);
+
+  useEffect(() => {
+    const uid = auth.currentUser.uid;
+    const unsub = onSnapshot(doc(db, 'users', uid), (docSnap) => {
+      setUserData(docSnap.data());
+    });
+    return unsub;
+  }, []);
+
+  if (!userData) return <View style={styles.container}><Text>Loading...</Text></View>;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Goal: {userData.goal}</Text>
+      <Text style={styles.text}>Level: {userData.level}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 18, marginVertical: 4 }
+});

--- a/react-native/src/screens/LoginScreen.js
+++ b/react-native/src/screens/LoginScreen.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase/config';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      navigation.replace('Dashboard');
+    } catch (e) {
+      console.log('Login error', e);
+    }
+  };
+
+  const handleSignup = async () => {
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+      navigation.replace('Onboarding');
+    } catch (e) {
+      console.log('Signup error', e);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Email" value={email} onChangeText={setEmail} style={styles.input}/>
+      <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} style={styles.input}/>
+      <Button title="Login" onPress={handleLogin} />
+      <Button title="Sign Up" onPress={handleSignup} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 10 }
+});

--- a/react-native/src/screens/OnboardingScreen.js
+++ b/react-native/src/screens/OnboardingScreen.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { doc, setDoc } from 'firebase/firestore';
+import { db, auth } from '../firebase/config';
+
+export default function OnboardingScreen({ navigation }) {
+  const [goal, setGoal] = useState('');
+  const [level, setLevel] = useState('');
+
+  const handleSave = async () => {
+    const uid = auth.currentUser.uid;
+    await setDoc(doc(db, 'users', uid), {
+      goal,
+      level
+    });
+    navigation.replace('Dashboard');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Fitness Goal" value={goal} onChangeText={setGoal} style={styles.input}/>
+      <TextInput placeholder="Fitness Level" value={level} onChangeText={setLevel} style={styles.input}/>
+      <Button title="Save" onPress={handleSave} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 10 }
+});


### PR DESCRIPTION
## Summary
- add root README introducing the React Native prototype
- ignore React Native build artifacts
- create basic React Native app using Expo
- add Firebase config and authentication flows
- provide onboarding and dashboard screens that sync to Firestore

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68705c199140832eba767c3b0eedbd9e